### PR TITLE
chore: maintainer role for jpower432

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,3 +3,5 @@ Compliance-to-Policy (C2P) was designed and open sourced by a team based at [IBM
 Takumi Yanagawa [yana1205](https://github.com/yana1205)
 
 Yuji Watanabe [yuji-watanabe-jp](https://github.com/yuji-watanabe-jp)
+
+Jennifer Power [jpower432](https://github.com/jpower432)


### PR DESCRIPTION
Completing a self-nomination process below

### Nominee
@jpower432 

- [X] I have read the [membership documentation](https://github.com/oscal-compass/community/blob/main/MEMBERSHIP.md)

### Eligibility

- [X] I have been a member of `oscal-compass` for at least a month

> Note: I currently hold a maintainer position in `compliance-trestle`

### Sponsporship

- [X] I have contacted the two project maintainers for C2P Go prior to this pull request


### Justification for the Role Change

I plan on contributing significantly to the [design and implementation](https://github.com/oscal-compass/compliance-to-policy-go/issues/2) of the `v2` module of C2P Go. I have been working on a prototype implementation to help get that work started.

I have contributions to C2P and C2P Go. I have listed a couple below.
- Completed work on issue [22](https://github.com/oscal-compass/compliance-to-policy/issues/22) to decouple Python from Go
- PR review in `compliance-to-policy` - https://github.com/oscal-compass/compliance-to-policy/pull/35



