### PR TITLE
fix: error handling for validation component

### DIFF
--- a/framework/manager.go
+++ b/framework/manager.go
@@ -108,7 +108,8 @@ func (m *PluginManager) GeneratePolicy(ctx context.Context, pluginSet map[string
 	for providerId, policyPlugin := range pluginSet {
 		componentTitle, ok := m.pluginIdMap[providerId]
 		if !ok {
-			return fmt.Errorf("missing title for provider %s", providerId)
+			m.log.Warn(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
+			continue
 		}
 		m.log.Debug(fmt.Sprintf("Generating policy for provider %s", providerId))
 


### PR DESCRIPTION
**Summary**

When generating a policy, the validation component title is necessary.
However, in a scenario where multiple plugins are available it could be valid that there is no validation component for all plugins.

This PR changes the behavior to only warn instead of return error.

**Rationale**

Fixes #69 