### PR TITLE
fix: updates reports to generate findings after AR creation

### DIFF
--- a/framework/actions/report_test.go
+++ b/framework/actions/report_test.go
@@ -72,6 +72,21 @@ func TestReport(t *testing.T) {
 	require.Len(t, ar.Results, 1)
 	require.Len(t, *ar.Results[0].Observations, 2)
 	require.Len(t, *ar.Results[0].Findings, 1)
+	findings := *ar.Results[0].Findings
+	relatedObs := *findings[0].RelatedObservations
+
+	// require that the observation is properly linked to the finding
+	require.Len(t, relatedObs, 1)
+	observationUUID := relatedObs[0].ObservationUuid
+
+	var found bool
+	for _, obs := range *ar.Results[0].Observations {
+		if obs.UUID == observationUUID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
 }
 
 func TestToOscalObservation(t *testing.T) {


### PR DESCRIPTION
Processing findings before Assessment Results can
lead to observations being filtered out by the Assessment Plan. This change ensures that findings are processed after Assessment Results are generated, ensuring the Observation UUID is accurate.