### PR TITLE
fix: adds `issues:write` permissions to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 #v5


### PR DESCRIPTION
- Updates permissions on the labeler GitHub Actions
- Tested on fork https://github.com/jpower432/compliance-to-policy-go/pull/2
