### PR TITLE
fix: removes Check_Id props from target component in testdata

### DIFF
--- a/pkg/testdata/oscal/component-definition-heterogeneous.json
+++ b/pkg/testdata/oscal/component-definition-heterogeneous.json
@@ -29,18 +29,6 @@
             "remarks": "rule_set_0"
           },
           {
-            "name": "Check_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "test_configuration_check",
-            "remarks": "rule_set_0"
-          },
-          {
-            "name": "Policy_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-high-scan",
-            "remarks": "rule_set_0"
-          },
-          {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
             "value": "test_proxy_check",
@@ -76,18 +64,6 @@
             "remarks": "rule_set_1"
           },
           {
-            "name": "Check_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "test_proxy_check",
-            "remarks": "rule_set_1"
-          },
-          {
-            "name": "Policy_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-deployment",
-            "remarks": "rule_set_1"
-          },
-          {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
             "value": "install_kyverno",
@@ -102,18 +78,6 @@
             "remarks": "rule_set_2"
           },
           {
-            "name": "Check_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-install-kyverno-from-manifests",
-            "remarks": "rule_set_2"
-          },
-          {
-            "name": "Policy_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-install-kyverno-from-manifests",
-            "remarks": "rule_set_2"
-          },
-          {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
             "value": "test_required_label",
@@ -125,18 +89,6 @@
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
             "value": "By Kyverno, ensure required labels are set",
             "class": "scc_class",
-            "remarks": "rule_set_3"
-          },
-          {
-            "name": "Check_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-kyverno-require-labels",
-            "remarks": "rule_set_3"
-          },
-          {
-            "name": "Policy_Id",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ibmcloud",
-            "value": "policy-kyverno-require-labels",
             "remarks": "rule_set_3"
           },
           {


### PR DESCRIPTION
Fixes #147 

This updates the testdata to ensure the `Check_Id` is only defined once and in the validation component.


To test:
```bash
c2pcli result2oscal -c docs/c2p-config.yaml -n nist_800_53 -o /tmp/assessment-results.fixed.json
grep "\"subjects\"" /tmp/assessment-results.fixed.json
# Outcome - there should be subjects
```