### PR TITLE
fix: resolve misaligned rule_set index in first props entry

### DIFF
--- a/pkg/testdata/oscal/component-definition-heterogeneous.json
+++ b/pkg/testdata/oscal/component-definition-heterogeneous.json
@@ -189,7 +189,7 @@
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd/ocm",
             "value": "test_configuration_check",
-            "remarks": "rule_set_1"
+            "remarks": "rule_set_0"
           },
           {
             "name": "Check_Id",


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>

I found a minor bug on test data. 
With this fix, the observation for cm-6 test_configuration_check is now correctly captured.

<img width="911" alt="image" src="https://github.com/user-attachments/assets/21778978-5b62-466f-bd1b-1f0df3aab8c8" />
