### PR TITLE
fix: updating nil check for control mappings

### DIFF
--- a/framework/actions/report.go
+++ b/framework/actions/report.go
@@ -55,11 +55,13 @@ func Report(ctx context.Context, inputContext *InputContext, planHref string, pl
 	rulesByControls := make(map[string][]string)
 	for _, act := range *plan.LocalDefinitions.Activities {
 		var controlSet []string
-		controls := act.RelatedControls.ControlSelections
-		for _, ctr := range controls {
-			for _, assess := range *ctr.IncludeControls {
-				targetId := fmt.Sprintf("%s_smt", assess.ControlId)
-				controlSet = append(controlSet, targetId)
+		if act.RelatedControls != nil {
+			controls := act.RelatedControls.ControlSelections
+			for _, ctr := range controls {
+				for _, assess := range *ctr.IncludeControls {
+					targetId := fmt.Sprintf("%s_smt", assess.ControlId)
+					controlSet = append(controlSet, targetId)
+				}
 			}
 		}
 		rulesByControls[act.Title] = controlSet


### PR DESCRIPTION
## Description

This PR is a quick fix to address the need for a nil check for the `RelatedControls`. 

## Related Issues 

- Closes Issue #154 

