### PR TITLE
refactor: adds concurrent plugin invocations in plugin-based actions

### DIFF
--- a/framework/actions/aggregate.go
+++ b/framework/actions/aggregate.go
@@ -7,9 +7,12 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/oscal-compass/oscal-sdk-go/settings"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/oscal-compass/compliance-to-policy-go/v2/logging"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
@@ -21,24 +24,68 @@ import (
 //
 // The rule set passed to each plugin can be configured with compliance specific settings based on the InputContext.
 func AggregateResults(ctx context.Context, inputContext *InputContext, pluginSet map[plugin.ID]policy.Provider) ([]policy.PVPResult, error) {
-	var allResults []policy.PVPResult
 	log := logging.GetLogger("aggregator")
-	for providerId, policyPlugin := range pluginSet {
-		componentTitle, err := inputContext.ProviderTitle(providerId)
-		if err != nil {
-			return nil, err
-		}
-		log.Debug(fmt.Sprintf("Aggregating results for provider %s", providerId))
-		appliedRuleSet, err := settings.ApplyToComponent(ctx, componentTitle, inputContext.Store(), inputContext.Settings)
-		if err != nil {
-			return allResults, fmt.Errorf("failed to get rule sets for component %s: %w", componentTitle, err)
-		}
 
-		pluginResults, err := policyPlugin.GetResults(appliedRuleSet)
-		if err != nil {
-			return allResults, fmt.Errorf("plugin %s: %w", providerId, err)
-		}
-		allResults = append(allResults, pluginResults)
+	var allResults []policy.PVPResult
+	sem := semaphore.NewWeighted(inputContext.MaxConcurrentWeight)
+	var wg sync.WaitGroup
+	errorCh := make(chan error, len(pluginSet))
+	resultChan := make(chan policy.PVPResult, len(pluginSet))
+
+	for providerId, policyPlugin := range pluginSet {
+
+		wg.Add(1)
+
+		go func(providerId plugin.ID, plugin policy.Provider) {
+			defer wg.Done()
+
+			if err := sem.Acquire(ctx, 1); err != nil {
+				errorCh <- fmt.Errorf("%s failed to acquire semaphore: %w", providerId.String(), err)
+				return
+			}
+			defer sem.Release(1)
+
+			componentTitle, err := inputContext.ProviderTitle(providerId)
+			if err != nil {
+				if errors.Is(err, ErrMissingProvider) {
+					log.Warn(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
+					return
+				}
+				errorCh <- err
+				return
+
+			}
+			log.Debug(fmt.Sprintf("Aggregating results for provider %s", providerId))
+
+			appliedRuleSet, err := settings.ApplyToComponent(ctx, componentTitle, inputContext.Store(), inputContext.Settings)
+			if err != nil {
+				errorCh <- fmt.Errorf("failed to get rule sets for component %s: %w", componentTitle, err)
+				return
+			}
+
+			pluginResults, err := policyPlugin.GetResults(appliedRuleSet)
+			if err != nil {
+				errorCh <- fmt.Errorf("plugin %s: %w", providerId, err)
+				return
+			}
+			resultChan <- pluginResults
+		}(providerId, policyPlugin)
 	}
-	return allResults, nil
+
+	go func() {
+		wg.Wait()
+		close(errorCh)
+		close(resultChan)
+	}()
+
+	var errs []error
+	for err := range errorCh {
+		errs = append(errs, err)
+	}
+
+	for result := range resultChan {
+		allResults = append(allResults, result)
+	}
+
+	return allResults, errors.Join(errs...)
 }

--- a/framework/actions/aggregate_test.go
+++ b/framework/actions/aggregate_test.go
@@ -7,14 +7,19 @@ package actions
 
 import (
 	"context"
+	"os"
 	"sort"
 	"testing"
 
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
+	"github.com/oscal-compass/oscal-sdk-go/models"
+	"github.com/oscal-compass/oscal-sdk-go/models/components"
 	"github.com/oscal-compass/oscal-sdk-go/settings"
+	"github.com/oscal-compass/oscal-sdk-go/validation"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/oscal-compass/compliance-to-policy-go/v2/pkg"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 )
@@ -87,6 +92,79 @@ func TestAggregateResults(t *testing.T) {
 	require.NoError(t, err)
 	providerTestObj.AssertExpectations(t)
 	require.Len(t, gotResults, 1)
+}
+
+func TestAggregateResults_Multi(t *testing.T) {
+	testDataPath := pkg.PathFromPkgDirectory("./testdata/oscal/component-definition-heterogeneous.json")
+	file, err := os.Open(testDataPath)
+	require.NoError(t, err)
+	definition, err := models.NewComponentDefinition(file, validation.NoopValidator{})
+	require.NoError(t, err)
+
+	var allComponents []components.Component
+	for _, component := range *definition.Components {
+		compAdapter := components.NewDefinedComponentAdapter(component)
+		allComponents = append(allComponents, compAdapter)
+	}
+
+	inputContext, err := NewContext(allComponents)
+	require.NoError(t, err)
+
+	testSettings := settings.NewSettings(map[string]struct{}{"test_configuration_check": {}, "allowed-base-images": {}}, nil)
+	inputContext.Settings = testSettings
+
+	wantResults := policy.PVPResult{
+		ObservationsByCheck: []policy.ObservationByCheck{
+			{
+				Title:       "Example",
+				Description: "Example description",
+				CheckID:     "test-check",
+			},
+		},
+	}
+
+	ocmRule := extensions.RuleSet{
+		Rule: extensions.Rule{
+			ID:          "test_configuration_check",
+			Description: "Ensure deployment configuration is securely set up",
+		},
+		Checks: []extensions.Check{
+			{
+				ID: "policy-high-scan",
+			},
+		},
+	}
+
+	kyvernoRule := extensions.RuleSet{
+		Rule: extensions.Rule{
+			ID:          "allowed-base-images",
+			Description: "Building images which specify a base as their origin is a good start to improving supply chain security, but over time organizations may want to build an allow list of specific base images which are allowed to be used when constructing containers. This policy ensures that a container's base, found in an OCI annotation, is in a cluster-wide allow list.",
+		},
+		Checks: []extensions.Check{
+			{
+				ID:          "allowed-base-images",
+				Description: "allowed-base-images",
+			},
+		},
+	}
+
+	// Create pluginSet
+	providerTestObj := new(policyProvider)
+	providerTestObj.On("GetResults", policy.Policy{ocmRule}).Return(wantResults, nil)
+
+	// Create pluginSet
+	providerTestObj2 := new(policyProvider)
+	providerTestObj2.On("GetResults", policy.Policy{kyvernoRule}).Return(wantResults, nil)
+	pluginSet := map[plugin.ID]policy.Provider{
+		"ocm":     providerTestObj,
+		"kyverno": providerTestObj2,
+	}
+
+	gotResults, err := AggregateResults(context.TODO(), inputContext, pluginSet)
+	require.NoError(t, err)
+	providerTestObj.AssertExpectations(t)
+	providerTestObj2.AssertExpectations(t)
+	require.Len(t, gotResults, 2)
 }
 
 // policyProvider is a mocked implementation of policy.Provider.

--- a/framework/actions/input.go
+++ b/framework/actions/input.go
@@ -35,12 +35,15 @@ type InputContext struct {
 	rulesStore rules.Store
 	// Settings define adjustable rule settings parsed from framework-specific implementation
 	Settings settings.Settings
+	// action concurrency
+	MaxConcurrentWeight int64
 }
 
 // NewContext returns an InputContext for the given OSCAL Components.
 func NewContext(components []components.Component) (*InputContext, error) {
 	inputCtx := &InputContext{
-		requestedProviders: make(map[plugin.ID]string),
+		requestedProviders:  make(map[plugin.ID]string),
+		MaxConcurrentWeight: 3,
 	}
 	for _, comp := range components {
 		if comp.Type() == pluginComponentType {


### PR DESCRIPTION
This update allows plugin-based operations to be executed concurrently using a fan out, fan in approach.
This is benefical when scaling up the number of plugins used, espcially plugins with longer running scan times.

Closes #137 