### PR TITLE
fix: adds gosec to golangci-lint and fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,19 +10,23 @@ linters:
     - durationcheck
     - errname
     - errorlint
-    - govet
+    - gosec
     - importas
-    - ineffassign
     - misspell
     - nilerr
-    - unconvert
     - nolintlint
+    - unconvert
   disable:
     # Revisit issues in the codebase with these linters
     # and re-enable
     - errcheck
     - staticcheck
     - unused
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
 
 formatters:
   enable:

--- a/cmd/c2pcli/cli/subcommands/config.go
+++ b/cmd/c2pcli/cli/subcommands/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/oscal-compass/oscal-sdk-go/models"
@@ -81,7 +82,7 @@ func createOrGetPlan(ctx context.Context, option *Options) (*oscalTypes.Assessme
 }
 
 func loadCompDef(path string) (oscalTypes.ComponentDefinition, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return oscalTypes.ComponentDefinition{}, err
 	}
@@ -98,7 +99,7 @@ func loadCompDef(path string) (oscalTypes.ComponentDefinition, error) {
 }
 
 func loadPlan(path string) (*oscalTypes.AssessmentPlan, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/c2pcli/cli/subcommands/oscal2posture.go
+++ b/cmd/c2pcli/cli/subcommands/oscal2posture.go
@@ -93,7 +93,7 @@ func runOSCAL2Posture(ctx context.Context, option *Options) error {
 	if out == "-" {
 		fmt.Fprintln(os.Stdout, string(data))
 	} else {
-		return os.WriteFile(out, data, os.ModePerm)
+		return os.WriteFile(out, data, 0600)
 	}
 	return nil
 }

--- a/cmd/decompose/decompose.go
+++ b/cmd/decompose/decompose.go
@@ -36,11 +36,11 @@ func main() {
 	logger, _ := zap.NewDevelopment()
 
 	parsedResultsDir := outputDir + "/parsed"
-	if err := os.MkdirAll(parsedResultsDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(parsedResultsDir, 0750); err != nil {
 		panic(err)
 	}
 	decomposedResultsDir := outputDir + "/decomposed"
-	if err := os.MkdirAll(decomposedResultsDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(decomposedResultsDir, 0750); err != nil {
 		panic(err)
 	}
 

--- a/cmd/ocm-plugin/server/server.go
+++ b/cmd/ocm-plugin/server/server.go
@@ -66,7 +66,7 @@ func (p *Plugin) Generate(pl policy.Policy) error {
 		}
 		fnamesTokens := []string{kind, namespace, name}
 		fname := strings.Join(fnamesTokens, ".") + ".yaml"
-		if err := os.WriteFile(p.config.OutputDir+"/"+fname, yamlByte, os.ModePerm); err != nil {
+		if err := os.WriteFile(p.config.OutputDir+"/"+fname, yamlByte, 0600); err != nil {
 			return err
 		}
 	}

--- a/cmd/parse-single/parse-single.go
+++ b/cmd/parse-single/parse-single.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"path/filepath"
 
 	"github.com/oscal-compass/compliance-to-policy-go/v2/internal/parser"
 )
@@ -38,12 +39,14 @@ func main() {
 	flag.StringVar(&outputDir, "out", "./out", "output")
 	flag.Parse()
 
-	if err := os.Mkdir(outputDir, os.ModePerm); err != nil {
+	if err := os.Mkdir(outputDir, 0750); err != nil {
 		panic(err)
 	}
 
 	collector := parser.NewCollector(outputDir)
-	in, err := os.Open(policyPath)
+
+	cleanedPath := filepath.Clean(policyPath)
+	in, err := os.Open(cleanedPath)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/parse/modules/parse.go
+++ b/cmd/parse/modules/parse.go
@@ -140,7 +140,7 @@ func appendCompliance(c *parser.Collector) error {
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(policyDir+"/compliance.yaml", yamlData, os.ModePerm); err != nil {
+		if err := os.WriteFile(policyDir+"/compliance.yaml", yamlData, 0600); err != nil {
 			return err
 		}
 	}
@@ -153,13 +153,13 @@ func indexer(c *parser.Collector) error {
 	filenameCreator := utils.NewFilenameCreator(".yaml", nil)
 	for apiVersion, table := range groupedByApiVersion {
 		apiVersionDir := resourcesDir + "/" + apiVersion
-		if err := os.MkdirAll(apiVersionDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(apiVersionDir, 0750); err != nil {
 			return err
 		}
 		groupedByKind := table.GroupBy("kind")
 		for kind, table := range groupedByKind {
 			kindDir := apiVersionDir + "/" + kind
-			if err := os.MkdirAll(kindDir, os.ModePerm); err != nil {
+			if err := os.MkdirAll(kindDir, 0750); err != nil {
 				return err
 			}
 			for _, row := range table.List() {

--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -42,7 +42,7 @@ func main() {
 
 	logger, _ := zap.NewDevelopment()
 
-	if err := os.Mkdir(outputDir, os.ModePerm); err != nil {
+	if err := os.Mkdir(outputDir, 0750); err != nil {
 		panic(err)
 	}
 

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 
@@ -41,7 +42,9 @@ func main() {
 		panic(err)
 	}
 	println(u)
-	f, err := os.Open(resourceTableFile)
+
+	cleanedPath := filepath.Clean(resourceTableFile)
+	f, err := os.Open(cleanedPath)
 	if err != nil {
 		panic(err)
 	}
@@ -99,7 +102,7 @@ func main() {
 			panic(err)
 		}
 		_ = count
-		writer.Flush()
+		_ = writer.Flush()
 	} else {
 		t.Filter(filterFunc).Print()
 	}

--- a/internal/decomposer/decomposer.go
+++ b/internal/decomposer/decomposer.go
@@ -33,7 +33,7 @@ type Decomposer struct {
 }
 
 func NewDecomposer(resourceTableFile io.Reader, outputDirPath string) (*Decomposer, error) {
-	if err := os.MkdirAll(outputDirPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(outputDirPath, 0750); err != nil {
 		return nil, err
 	}
 	return &Decomposer{

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -73,7 +73,7 @@ func (c *Collector) GetOutputDir() string {
 
 func (c *Collector) TraversalFunc(target string) func(path string, info os.FileInfo, err error) error {
 	outputTargetDir := c.outputDir + "/" + target
-	_ = os.MkdirAll(outputTargetDir, os.ModePerm)
+	_ = os.MkdirAll(outputTargetDir, 0750)
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -96,7 +96,7 @@ func (c *Collector) parseFile(target string, outputDir string, path string, file
 		return fmt.Errorf("No policies are found for %s.", target)
 	}
 	placementDir := outputDir + "/placements"
-	if err := os.MkdirAll(placementDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(placementDir, 0750); err != nil {
 		return err
 	}
 	for _, pb := range placementBindings {
@@ -178,9 +178,10 @@ func (c *Collector) parseFile(target string, outputDir string, path string, file
 
 func (c *Collector) ParseFile(target string, outputTargetDir string, path string, info os.FileInfo, _err error) error {
 	fname := info.Name()
+
 	outputDir := outputTargetDir + "/" + fname
 	outputDir = strings.ReplaceAll(outputDir, ".yaml", "")
-	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
 		return err
 	}
 	if err := utils.CopyFile(path, outputDir+"/policy.yaml"); err != nil {
@@ -189,7 +190,8 @@ func (c *Collector) ParseFile(target string, outputTargetDir string, path string
 
 	logger.Info(fmt.Sprintf("%s, %s", path, fname))
 
-	f, err := os.Open(path)
+	cleanedPath := filepath.Clean(path)
+	f, err := os.Open(cleanedPath)
 	if err != nil {
 		return err
 	}
@@ -215,7 +217,7 @@ func (c *Collector) parsePolicyTemplate(policyTemplate *policy.PolicyTemplate, b
 	}
 	row.ConfigPolicy = configPolicy.Name
 	configPolicyDir := row.PolicyDir + "/" + configPolicy.Name
-	if err := os.MkdirAll(configPolicyDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(configPolicyDir, 0750); err != nil {
 		return manifests, err
 	}
 	remediationAction := configPolicy.Spec.RemediationAction

--- a/internal/parser/util.go
+++ b/internal/parser/util.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package parser
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 func WriteToCSVs(c *Collector, outputDir string) (string, string) {
 	policyCsvPath := outputDir + "/policies.csv"
+	policyCsvPath = filepath.Clean(policyCsvPath)
 	of, err := os.Create(policyCsvPath)
 	if err != nil {
 		panic(err)
@@ -27,6 +31,8 @@ func WriteToCSVs(c *Collector, outputDir string) (string, string) {
 	c.GetTable().ToCsv(of)
 
 	resourcesCsvPath := outputDir + "/resources.csv"
+	resourcesCsvPath = filepath.Clean(resourcesCsvPath)
+
 	of, err = os.Create(resourcesCsvPath)
 	if err != nil {
 		panic(err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -56,7 +57,7 @@ func GetLogger(name string) *zap.Logger {
 }
 
 func LoadYaml(path string) ([]*unstructured.Unstructured, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
@@ -99,12 +100,13 @@ func NilIfEmpty[T any](slice *[]T) *[]T {
 }
 
 func CopyFile(src string, dest string) error {
-	input, err := os.ReadFile(src)
+	cleanedPath := filepath.Clean(src)
+	input, err := os.ReadFile(cleanedPath)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(dest, input, os.ModePerm)
+	err = os.WriteFile(dest, input, 0600)
 	if err != nil {
 		return err
 	}
@@ -112,7 +114,7 @@ func CopyFile(src string, dest string) error {
 }
 
 func MakeDir(path string) (string, error) {
-	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+	if err := os.MkdirAll(path, 0750); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -129,12 +131,13 @@ func WriteObjToYamlFile(path string, in interface{}) error {
 	if yamlData, err := sigyaml.Marshal(in); err != nil {
 		return err
 	} else {
-		return os.WriteFile(path, yamlData, os.ModePerm)
+		return os.WriteFile(path, yamlData, 0600)
 	}
 }
 
 func WriteObjToYamlFileByGoYaml(path string, in interface{}) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	cleanedPath := filepath.Clean(path)
+	file, err := os.OpenFile(cleanedPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -147,7 +150,7 @@ func WriteObjToJsonFile(path string, in interface{}) error {
 	if jsonData, err := json.MarshalIndent(in, "", "\t"); err != nil {
 		return err
 	} else {
-		return os.WriteFile(path, jsonData, os.ModePerm)
+		return os.WriteFile(path, jsonData, 0600)
 	}
 }
 
@@ -155,7 +158,8 @@ func WriteObjToJsonFile(path string, in interface{}) error {
 // Maps and pointers (to a struct, string, int, etc) are accepted as out
 // values.
 func LoadYamlFileToObject(path string, out interface{}) error {
-	yamlData, err := os.ReadFile(path)
+	cleanedPath := filepath.Clean(path)
+	yamlData, err := os.ReadFile(cleanedPath)
 	if err != nil {
 		return err
 	}
@@ -166,7 +170,8 @@ func LoadYamlFileToObject(path string, out interface{}) error {
 }
 
 func LoadJsonFileToObject(path string, out interface{}) error {
-	jsonData, err := os.ReadFile(path)
+	cleanedPath := filepath.Clean(path)
+	jsonData, err := os.ReadFile(cleanedPath)
 	if err != nil {
 		return err
 	}
@@ -177,7 +182,8 @@ func LoadJsonFileToObject(path string, out interface{}) error {
 }
 
 func LoadYamlFileToK8sTypedObject(path string, out interface{}) error {
-	yamlData, err := os.ReadFile(path)
+	cleanedPath := filepath.Clean(path)
+	yamlData, err := os.ReadFile(cleanedPath)
 	if err != nil {
 		return err
 	}

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -160,7 +160,8 @@ func manifestMatchesType(manifest Manifest, pluginType string) bool {
 
 // readManifestFile reads and parses the manifest from JSON.
 func readManifestFile(pluginName ID, manifestPath string) (Manifest, error) {
-	manifestFile, err := os.Open(manifestPath)
+	cleanedPath := filepath.Clean(manifestPath)
+	manifestFile, err := os.Open(cleanedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return Manifest{}, &ManifestNotFoundError{File: manifestPath, PluginID: pluginName.String()}

--- a/plugin/initialization.go
+++ b/plugin/initialization.go
@@ -61,8 +61,11 @@ func ClientFactory(logger hclog.Logger) ClientFactoryFunc {
 			Managed:          true,
 			AutoMTLS:         true,
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
-			Cmd:              exec.Command(manifest.ExecutablePath),
-			Plugins:          SupportedPlugins,
+			// The #nosec comment is added with justification that by using manifest.ResolvePath()
+			// the manifest.ExecutablePath is validated as a plugin in the user-specified directory
+			// and sanitized.
+			Cmd:     exec.Command(manifest.ExecutablePath), /* #nosec G204 */
+			Plugins: SupportedPlugins,
 			SecureConfig: &plugin.SecureConfig{
 				Checksum: manifestSum,
 				Hash:     sha256.New(),

--- a/plugin/manifest.go
+++ b/plugin/manifest.go
@@ -43,10 +43,10 @@ func (m *Manifest) ResolvePath(pluginDir string) error {
 	// Handle different path types (relative and absolute)
 	var cleanedPath string
 	if filepath.IsAbs(m.ExecutablePath) {
-		if !strings.HasPrefix(m.ExecutablePath, absPluginDir+string(os.PathSeparator)) {
+		cleanedPath = filepath.Clean(m.ExecutablePath)
+		if !strings.HasPrefix(cleanedPath, absPluginDir+string(os.PathSeparator)) {
 			return fmt.Errorf("absolute path %s is not under the plugin directory %s", m.ExecutablePath, absPluginDir)
 		}
-		cleanedPath = filepath.Clean(m.ExecutablePath)
 	} else {
 		cleanedPath = filepath.Clean(filepath.Join(absPluginDir, m.ExecutablePath))
 	}


### PR DESCRIPTION
This PR as `gosec` to the `golangci-lint` enabled linters and associated fixes.