### PR TITLE
fix: removes extra logging statement from kyverno plugin

### DIFF
--- a/cmd/kyverno-plugin/server/fileloader.go
+++ b/cmd/kyverno-plugin/server/fileloader.go
@@ -55,7 +55,6 @@ func (fl *FileLoader) GetPolicyResourceIndice() []PolicyResourceIndex {
 }
 
 func (fl *FileLoader) LoadFromDirectory(dir string) error {
-	logger.Info("dddff")
 	re := regexp.MustCompile(`^[\.*]`)
 	callback := func(path string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
Removes a logging statement that appears to be there by mistake (possibly left in during testing)