### PR TITLE
fix: updates the Context function to include target components

### DIFF
--- a/cmd/c2pcli/cli/subcommands/config_test.go
+++ b/cmd/c2pcli/cli/subcommands/config_test.go
@@ -1,0 +1,107 @@
+package subcommands
+
+import (
+	"testing"
+
+	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	testOptions := &Options{}
+
+	tests := []struct {
+		name      string
+		ap        *oscalTypes.AssessmentPlan
+		wantError string
+	}{
+		{
+			name: "Success/HappyPath",
+			ap: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "my-activity",
+							UUID:  "example-3",
+							Steps: &[]oscalTypes.Step{
+								{
+									Title: "my-step",
+									UUID:  "example-4",
+								},
+							},
+						},
+					},
+					Components: &[]oscalTypes.SystemComponent{
+						{
+							UUID:  "uuid-1",
+							Title: "example",
+						},
+					},
+				},
+				AssessmentAssets: &oscalTypes.AssessmentAssets{
+					Components: &[]oscalTypes.SystemComponent{
+						{
+							UUID:  "uuid-2",
+							Title: "example-validation",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "Invalid/NoActivities",
+			wantError: "no activities found in assessment plan \"My Plan\"",
+			ap: &oscalTypes.AssessmentPlan{
+				Metadata: oscalTypes.Metadata{
+					Title: "My Plan",
+				},
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Components: &[]oscalTypes.SystemComponent{
+						{
+							UUID:  "uuid-1",
+							Title: "example",
+						},
+					},
+				},
+				AssessmentAssets: &oscalTypes.AssessmentAssets{
+					Components: &[]oscalTypes.SystemComponent{
+						{
+							UUID:  "uuid-2",
+							Title: "example-validation",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "Invalid/MissingComponent",
+			wantError: "missing components in assessment plan \"My Plan\"",
+			ap: &oscalTypes.AssessmentPlan{
+				Metadata: oscalTypes.Metadata{
+					Title: "My Plan",
+				},
+				LocalDefinitions: &oscalTypes.LocalDefinitions{},
+				AssessmentAssets: &oscalTypes.AssessmentAssets{
+					Components: &[]oscalTypes.SystemComponent{
+						{
+							UUID:  "uuid-2",
+							Title: "example-validation",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Context(testOptions, test.ap)
+			if test.wantError != "" {
+				require.EqualError(t, err, test.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+}

--- a/framework/actions/aggregate_test.go
+++ b/framework/actions/aggregate_test.go
@@ -110,7 +110,7 @@ func TestAggregateResults_Multi(t *testing.T) {
 		allComponents = append(allComponents, compAdapter)
 	}
 
-	inputContext, err := NewContext(allComponents)
+	inputContext, err := NewContextFromComponents(allComponents)
 	require.NoError(t, err)
 
 	testSettings := settings.NewSettings(map[string]struct{}{"test_configuration_check": {}, "allowed-base-images": {}}, nil)

--- a/framework/actions/input.go
+++ b/framework/actions/input.go
@@ -39,27 +39,31 @@ type InputContext struct {
 	MaxConcurrency int
 }
 
-// NewContext returns an InputContext for the given OSCAL Components.
-func NewContext(components []components.Component) (*InputContext, error) {
-	inputCtx := &InputContext{
-		requestedProviders: make(map[plugin.ID]string),
+func NewContext(providers map[plugin.ID]string, store rules.Store) *InputContext {
+	return &InputContext{
+		requestedProviders: providers,
+		rulesStore:         store,
 		MaxConcurrency:     3,
 	}
+}
+
+// NewContextFromComponents returns an InputContext for the given OSCAL Components.
+func NewContextFromComponents(components []components.Component) (*InputContext, error) {
+	requestedProviders := make(map[plugin.ID]string)
 	for _, comp := range components {
 		if comp.Type() == pluginComponentType {
 			pluginId, err := GetPluginIDFromComponent(comp)
 			if err != nil {
-				return inputCtx, err
+				return nil, err
 			}
-			inputCtx.requestedProviders[pluginId] = comp.Title()
+			requestedProviders[pluginId] = comp.Title()
 		}
 	}
 	store, err := DefaultStore(components)
 	if err != nil {
-		return inputCtx, err
+		return nil, err
 	}
-	inputCtx.rulesStore = store
-	return inputCtx, nil
+	return NewContext(requestedProviders, store), nil
 }
 
 // RequestedProviders returns the provider ids requested in the parsed input.

--- a/framework/actions/input_test.go
+++ b/framework/actions/input_test.go
@@ -96,7 +96,7 @@ func inputContextHelper(t *testing.T) *InputContext {
 		allComponents = append(allComponents, compAdapter)
 	}
 
-	inputContext, err := NewContext(allComponents)
+	inputContext, err := NewContextFromComponents(allComponents)
 	require.NoError(t, err)
 	return inputContext
 }

--- a/framework/actions/report_test.go
+++ b/framework/actions/report_test.go
@@ -322,7 +322,7 @@ func inputContextHelperPlan(t *testing.T) (*InputContext, oscalTypes.AssessmentP
 		allComponents = append(allComponents, compAdapter)
 	}
 
-	inputContext, err := NewContext(allComponents)
+	inputContext, err := NewContextFromComponents(allComponents)
 	require.NoError(t, err)
 	return inputContext, *ap
 }


### PR DESCRIPTION
## Summary

The Context function in config.go was not including components under the LocalDefinitions which caused the parameters properties to get lost. This change adds that information in and adds clarity to the NewContext function creating action Input.

Closes #176 