### PR TITLE
chore: updates golang version to 1.24 in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser-workflow.yml
+++ b/.github/workflows/goreleaser-workflow.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v6
       with:
-        go-version: v1.23
+        go-version: v1.24
     - name: Install cosign
       uses: sigstore/cosign-installer@v3.9.2
     - name: Install syft


### PR DESCRIPTION
Updates the go version use by goreleaser to fix CI workflow issue https://github.com/oscal-compass/compliance-to-policy-go/actions/runs/17796057965